### PR TITLE
PhotoPrism now has read-only support for AVIF images.

### DIFF
--- a/blog/tutorials/photoprism.mdx
+++ b/blog/tutorials/photoprism.mdx
@@ -5,11 +5,12 @@ keyword: PhotoPrism
 subcategory: graphics
 support: no
 datePublished: 2020-11-30
-dateModified: 2021-09-21
+dateModified: 2022-09-15
 sources:
   - ko.wikipedia.org/wiki/AV1
   - github.com/photoprism/photoprism
   - github.com/photoprism/photoprism/issues/668
+  - github.com/photoprism/photoprism/issues/2706
   - photoprism.app/features
   - docs.photoprism.org/
   - hub.docker.com/r/photoprism/photoprism
@@ -32,4 +33,4 @@ PhotoPrism is a privately hosted application that allows you to browse, organize
 
 ## AVIF support
 
-On November 30th, 2020, a Github issue was published that requested WebP support. In the discussion regarding the implementation of WebP, it was discovered that the developers thought it was worth waiting for AVIF, as support is growing and AVIF offers better compression, as well as animations. They are also excited about JPEG XL. It is unclear if they will add support in the future, as the ticket is still open, and no branch has been created to add AVIF support. AVIF will likely be supported in the future.
+On November 30th, 2020, a Github issue was published that requested WebP support. In the discussion regarding the implementation of WebP, it was discovered that the developers thought it was worth waiting for AVIF, as support is growing and AVIF offers better compression, as well as animations. They are also excited about JPEG XL. Read-only support was added on September 15th, 2022.

--- a/blog/tutorials/photoprism.mdx
+++ b/blog/tutorials/photoprism.mdx
@@ -3,7 +3,7 @@ title: PhotoPrism AVIF support
 description: PhotoPrism is an open-source Photo Management software. Find out if PhotoPrism already supports AVIF.
 keyword: PhotoPrism
 subcategory: graphics
-support: no
+support: full
 datePublished: 2020-11-30
 dateModified: 2022-09-15
 sources:


### PR DESCRIPTION
Since September 15th, as commented by one of the authors in issues [668](https://github.com/photoprism/photoprism/issues/668#issuecomment-1247394905) and [2706](https://github.com/photoprism/photoprism/issues/2706#issuecomment-1247400303).